### PR TITLE
Add support for CHERI-enabled DMA

### DIFF
--- a/portable/NetworkInterface/RISC-V/NetworkInterface.c
+++ b/portable/NetworkInterface/RISC-V/NetworkInterface.c
@@ -109,7 +109,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
 #endif
-	XAxiDma_BdSetBufAddr(BdPtr,(u32)xTxBuffer);
+	XAxiDma_BdSetBufAddr(BdPtr,xTxBuffer);
 	XAxiDma_BdSetLength(BdPtr, pxNetworkBuffer->xDataLength, TxRingPtr->MaxTransferLen);
 	XAxiDma_BdSetCtrl(BdPtr, XAXIDMA_BD_CTRL_TXSOF_MASK |
 			     XAXIDMA_BD_CTRL_TXEOF_MASK);

--- a/portable/NetworkInterface/RISC-V/riscv_hal_eth.c
+++ b/portable/NetworkInterface/RISC-V/riscv_hal_eth.c
@@ -479,17 +479,29 @@ int DmaSetup(XAxiDma *DmaInstancePtr, u16 AxiDmaDeviceId)
 
         #ifdef __CHERI_PURE_CAPABILITY__
             RxFrameBufRef = cheri_build_data_cap(RX_FRAME_BUF_ADDR, sizeof(EthernetFrame)*RXBD_CNT,
+                               __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__ |
                                __CHERI_CAP_PERMISSION_PERMIT_LOAD__ |
                                __CHERI_CAP_PERMISSION_PERMIT_STORE__);
             TxFrameBufRef = cheri_build_data_cap(TX_FRAME_BUF_ADDR, sizeof(EthernetFrame)*TXBD_CNT,
+                               __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__ |
                                __CHERI_CAP_PERMISSION_PERMIT_LOAD__ |
                                __CHERI_CAP_PERMISSION_PERMIT_STORE__);
             RxBdSpaceRef = cheri_build_data_cap(RXBD_SPACE_ADDR, RXBD_SPACE_BYTES,
-                               __CHERI_CAP_PERMISSION_PERMIT_LOAD__ |
-                               __CHERI_CAP_PERMISSION_PERMIT_STORE__);
+                               __CHERI_CAP_PERMISSION_GLOBAL__
+                               | __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__
+                               | __CHERI_CAP_PERMISSION_PERMIT_LOAD__
+                               | __CHERI_CAP_PERMISSION_PERMIT_STORE__
+                               | __CHERI_CAP_PERMISSION_PERMIT_STORE_CAPABILITY__
+                               | __CHERI_CAP_PERMISSION_PERMIT_STORE_LOCAL__
+                               | __CHERI_CAP_PERMISSION_PERMIT_LOAD_CAPABILITY__ );
             TxBdSpaceRef = cheri_build_data_cap(TXBD_SPACE_ADDR, TXBD_SPACE_BYTES,
-                               __CHERI_CAP_PERMISSION_PERMIT_LOAD__ |
-                               __CHERI_CAP_PERMISSION_PERMIT_STORE__);
+                               __CHERI_CAP_PERMISSION_GLOBAL__
+                               | __CHERI_CAP_PERMISSION_PERMIT_EXECUTE__
+                               | __CHERI_CAP_PERMISSION_PERMIT_LOAD__
+                               | __CHERI_CAP_PERMISSION_PERMIT_STORE__
+                               | __CHERI_CAP_PERMISSION_PERMIT_STORE_CAPABILITY__
+                               | __CHERI_CAP_PERMISSION_PERMIT_STORE_LOCAL__
+                               | __CHERI_CAP_PERMISSION_PERMIT_LOAD_CAPABILITY__ );
         #else
             TxFrameBufRef = (uint8_t *)0x80000000;
             RxFrameBufRef = (uint8_t *)(TxFrameBufRef + TXBD_CNT * sizeof(EthernetFrame));


### PR DESCRIPTION
Add Support for CHERI-enabled DMA

Description
-----------
This pull request is a request for comments on how CHERI-enabled DMA could be implemented. This is related to https://github.com/CTSRD-CHERI/RISC-V_Galois_demo/pull/1

The permissions granted to the DMA engine are not final and should be tightened later.
When tightening the permissions it might make more sense to have two separate sets of capabilities for accessing buffers - one set with R/W permissions for software to use, and one with only R (for TX buffers) or only W (for RX buffers) for the DMA engine to use.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
